### PR TITLE
Missing Commented Line

### DIFF
--- a/EclipsingBinaries/apass.py
+++ b/EclipsingBinaries/apass.py
@@ -511,6 +511,6 @@ def decimal_limit(a):
     return b
 
 
-comparison_selector()
+# comparison_selector()
 # overlay("APASS_254037_Rc_values.txt", "NSVS_254037-B.radec")
 # find_comp()


### PR DESCRIPTION
Without this missing comment line, the program will automatically run `apass.py` comparison selector without the user requesting this.